### PR TITLE
Share a draft of any post type

### DIFF
--- a/shareadraft.php
+++ b/shareadraft.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'Share_a_Draft' ) ) :
 			global $current_user;
 			$unpublished_statuses = array( 'pending', 'draft', 'future', 'private' );
 			$my_unpublished = get_posts( array(
-                'post_type' => 'any',
+				'post_type' => 'any',
 				'post_status' => $unpublished_statuses,
 				'author' => $current_user->ID,
 				// some environments, like WordPress.com hook on those filters
@@ -174,7 +174,7 @@ if ( ! class_exists( 'Share_a_Draft' ) ) :
 				'suppress_filters' => false,
 			) );
 			$others_unpublished = get_posts( array(
-                'post_type' => 'any',
+				'post_type' => 'any',
 				'post_status' => $unpublished_statuses,
 				'author' => -$current_user->ID,
 				'suppress_filters' => false,

--- a/shareadraft.php
+++ b/shareadraft.php
@@ -78,7 +78,7 @@ if ( ! class_exists( 'Share_a_Draft' ) ) :
 		}
 
 		function add_admin_pages() {
-			add_submenu_page( 'edit.php', __( 'Share a Draft', 'shareadraft' ), __( 'Share a Draft', 'shareadraft' ),
+			add_submenu_page( 'tools.php', __( 'Share a Draft', 'shareadraft' ), __( 'Share a Draft', 'shareadraft' ),
 			'edit_posts', __FILE__, array( $this, 'output_existing_menu_sub_admin_page' ) );
 		}
 
@@ -166,6 +166,7 @@ if ( ! class_exists( 'Share_a_Draft' ) ) :
 			global $current_user;
 			$unpublished_statuses = array( 'pending', 'draft', 'future', 'private' );
 			$my_unpublished = get_posts( array(
+                'post_type' => 'any',
 				'post_status' => $unpublished_statuses,
 				'author' => $current_user->ID,
 				// some environments, like WordPress.com hook on those filters
@@ -173,6 +174,7 @@ if ( ! class_exists( 'Share_a_Draft' ) ) :
 				'suppress_filters' => false,
 			) );
 			$others_unpublished = get_posts( array(
+                'post_type' => 'any',
 				'post_status' => $unpublished_statuses,
 				'author' => -$current_user->ID,
 				'suppress_filters' => false,


### PR DESCRIPTION
Hello there!

I updated the plugin to enable users to share any post type.

I also moved the page to be a submenu item under `tools.php` instead of creating a bunch of pages under each post type.
It personally felt nicer to have this "tool" in one place if you for instance have lots of different post types. What do you think?