### PR TITLE
Fix PHP 8.2 deprecation warnings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: nbachiyski, automattic
 Tags: post, post, draft, posts, drafts, share, sharing
 Requires at least: 4.0
-Tested up to: 5.8
+Tested up to: 6.8
 Stable tag: trunk
 
 Share private preview links to your drafts
@@ -32,6 +32,9 @@ e.g.
 
 
 == Changelog ==
+
+= 1.6 =
+* Fix PHP deprecation warnings
 
 = 1.5 =
 * Test with newest WordPress versions

--- a/shareadraft.php
+++ b/shareadraft.php
@@ -4,7 +4,7 @@ Plugin Name: Share a Draft
 Plugin URI: http://wordpress.org/plugins/shareadraft/
 Description: Share private preview links to your drafts
 Author: Nikolay Bachiyski, Automattic
-Version: 1.5
+Version: 1.6
 Author URI: https://extrapolate.me/
 Text Domain: shareadraft
 Domain Path: /languages
@@ -14,6 +14,8 @@ if ( ! class_exists( 'Share_a_Draft' ) ) :
 	class Share_a_Draft {
 		var $admin_options_name = 'ShareADraft_options';
 		var $shared_post = null;
+		var $admin_options = array();
+		var $user_options = array();
 
 		function __construct() {
 			add_action( 'init', array( $this, 'init' ) );


### PR DESCRIPTION
The undeclared properties cause PHP deprecation warnings in PHP 8.2, and may cause fatal errors in PHP 9. This PR declares the properties to remove the warnings.