### PR TITLE
Support multiple post types

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Share private preview links to your drafts
 Drafts in WordPress are visible for the author and blog administrators. In many cases, however, you want
 to share a draft with your friends or colleagues for either review or approval.
 
-Share a Draft allows you to create a unique link to a draft for a limited time and send it to whoever you want.
+Share a Draft allows you to create a unique temporary link to a draft and send it to whoever you want.
 
 == Installation ==
 
@@ -34,6 +34,8 @@ e.g.
 == Changelog ==
 
 = 1.6 =
+* Support all publicly queryable post types
+* Fix FSE compatibility
 * Fix PHP deprecation warnings
 
 = 1.5 =

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package Shareadraft
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
+
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php, have you run bin/install-wp-tests.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once "{$_tests_dir}/includes/functions.php";
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/shareadraft.php';
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require "{$_tests_dir}/includes/bootstrap.php";
+
+// Load base test case class
+require dirname( __FILE__ ) . '/class-shareadraft-testcase.php';

--- a/tests/class-shareadraft-testcase.php
+++ b/tests/class-shareadraft-testcase.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Base test case for Share a Draft tests
+ *
+ * Provides common setup and utility methods for all test classes.
+ */
+
+abstract class ShareADraft_TestCase extends WP_UnitTestCase {
+
+	/**
+	 * Plugin instance
+	 *
+	 * @var Share_a_Draft
+	 */
+	protected $plugin;
+
+	/**
+	 * Test user ID
+	 *
+	 * @var int
+	 */
+	protected $user_id;
+
+	/**
+	 * Registered test post types.
+	 *
+	 * @var array
+	 */
+	protected $_test_post_types = array();
+
+
+	public function setUp(): void {
+		parent::setUp();
+		global $__share_a_draft;
+
+		// Ensure plugin is instantiated
+		if ( ! $__share_a_draft ) {
+			$__share_a_draft = new Share_a_Draft();
+		}
+
+		$this->plugin = $__share_a_draft;
+
+		// Create and set test user with editor role
+		$this->user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $this->user_id );
+
+		// Initialize plugin for current user
+		$this->plugin->init();
+	}
+
+	/**
+	 * Helper: Create a draft post
+	 *
+	 * @param string $post_type Post type to create (default: 'post')
+	 * @param array  $args      Additional arguments
+	 * @return int Post ID
+	 */
+	protected function create_draft( $post_type = 'post', $args = array() ) {
+		$defaults = array(
+			'post_status' => 'draft',
+			'post_type'   => $post_type,
+			'post_title'  => 'Test ' . ucfirst( $post_type ),
+			'author'      => $this->user_id,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
+		return $this->factory->post->create( $args );
+	}
+
+	/**
+	 * Helper: Create a share for a post
+	 *
+	 * @param int   $post_id Post ID to share
+	 * @param array $params  Share parameters (expires, measure)
+	 * @return array|null Share data or null on failure
+	 */
+	protected function create_share( $post_id, $params = array() ) {
+		$defaults = array(
+			'post_id' => $post_id,
+			'expires' => 2,
+			'measure' => 'w',
+		);
+
+		$params = wp_parse_args( $params, $defaults );
+
+		$result = $this->plugin->process_new_share( $params );
+
+		// Return null if error
+		if ( $result ) {
+			return null;
+		}
+
+		$shares = $this->plugin->get_shared();
+		return end( $shares );
+	}
+
+	/**
+	 * Helper: Get share key for a post
+	 *
+	 * @param int $post_id Post ID
+	 * @return string|null Share key or null if not found
+	 */
+	protected function get_share_key( $post_id ) {
+		$shares = $this->plugin->get_shared();
+
+		foreach ( $shares as $share ) {
+			if ( $share['id'] === $post_id ) {
+				return $share['key'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Helper: Register a temporary post type for testing
+	 *
+	 * @param string $post_type Post type name
+	 * @param array  $args      Post type arguments
+	 * @return void
+	 */
+	protected function register_test_post_type( $post_type, $args = array() ) {
+		register_post_type( $post_type, $args );
+
+		// Store for cleanup in tearDown
+		if ( ! isset( $this->_test_post_types ) ) {
+			$this->_test_post_types = array();
+		}
+		$this->_test_post_types[] = $post_type;
+	}
+
+	/**
+	 * Clean up registered post types
+	 */
+	protected function unregister_test_post_types() {
+		if ( ! empty( $this->_test_post_types ) ) {
+			foreach ( $this->_test_post_types as $post_type ) {
+				unregister_post_type( $post_type );
+			}
+			$this->_test_post_types = array();
+		}
+	}
+
+	/**
+	 * Tear down test environment
+	 */
+	public function tearDown(): void {
+		// Clean up global state
+		unset( $_GET['shareadraft'] );
+
+		// Clean up test post types
+		$this->unregister_test_post_types();
+
+		parent::tearDown();
+	}
+}

--- a/tests/test-post-types.php
+++ b/tests/test-post-types.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Tests for post type support functionality
+ */
+
+class Test_ShareADraft_PostTypes extends ShareADraft_TestCase {
+
+	/**
+	 * Test that get_supported_post_types returns publicly queryable post types
+	 */
+	public function test_get_supported_post_types_returns_publicly_queryable() {
+		$supported = $this->plugin->get_supported_post_types();
+
+		// Should include built-in publicly queryable types
+		$this->assertContains( 'post', $supported );
+		$this->assertContains( 'page', $supported );
+	}
+
+	/**
+	 * Test that FSE post types are not in supported types
+	 */
+	public function test_fse_post_types_not_supported() {
+		$supported = $this->plugin->get_supported_post_types();
+
+		// FSE types should not be supported (not publicly queryable)
+		$this->assertNotContains( 'wp_template', $supported );
+		$this->assertNotContains( 'wp_template_part', $supported );
+		$this->assertNotContains( 'wp_navigation', $supported );
+		$this->assertNotContains( 'wp_block', $supported );
+	}
+
+	/**
+	 * Test that custom post types with publicly_queryable are supported
+	 */
+	public function test_custom_post_type_publicly_queryable_supported() {
+		// Register a publicly queryable custom post type
+		$this->register_test_post_type( 'event', array(
+			'public' => true,
+			'publicly_queryable' => true,
+		) );
+
+		$supported = $this->plugin->get_supported_post_types();
+		$this->assertContains( 'event', $supported );
+	}
+
+	/**
+	 * Test that custom post types without publicly_queryable are not supported
+	 */
+	public function test_custom_post_type_not_publicly_queryable_not_supported() {
+		// Register a non-publicly queryable custom post type
+		$this->register_test_post_type( 'internal_note', array(
+			'public' => true,
+			'publicly_queryable' => false,
+		) );
+
+		$supported = $this->plugin->get_supported_post_types();
+		$this->assertNotContains( 'internal_note', $supported );
+	}
+
+	/**
+	 * Test the shareadraft_supported_post_types filter hook
+	 */
+	public function test_supported_post_types_filter() {
+		$filter_callback = function( $post_types ) {
+			// Remove 'page' from supported types
+			return array_diff( $post_types, array( 'page' ) );
+		};
+
+		add_filter( 'shareadraft_supported_post_types', $filter_callback );
+
+		$supported = $this->plugin->get_supported_post_types();
+		$this->assertNotContains( 'page', $supported );
+		$this->assertContains( 'post', $supported );
+
+		remove_filter( 'shareadraft_supported_post_types', $filter_callback );
+	}
+
+	/**
+	 * Test that get_drafts only returns supported post types
+	 */
+	public function test_get_drafts_filters_by_supported_types() {
+		// Create drafts of different types
+		$post_id = $this->create_draft( 'post' );
+		$page_id = $this->create_draft( 'page' );
+
+		// Register and create a non-publicly-queryable type
+		$this->register_test_post_type( 'internal', array(
+			'public' => false,
+			'publicly_queryable' => false,
+		) );
+		$internal_id = $this->create_draft( 'internal' );
+
+		$draft_groups = $this->plugin->get_drafts();
+		$all_drafts = array_merge( $draft_groups[0]['posts'], $draft_groups[1]['posts'] );
+		$draft_ids = wp_list_pluck( $all_drafts, 'ID' );
+
+		// Should include post and page
+		$this->assertContains( $post_id, $draft_ids );
+		$this->assertContains( $page_id, $draft_ids );
+
+		// Should NOT include internal type
+		$this->assertNotContains( $internal_id, $draft_ids );
+	}
+}

--- a/tests/test-query-interception.php
+++ b/tests/test-query-interception.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Tests for query interception and FSE edge cases
+ */
+
+class Test_ShareADraft_QueryInterception extends ShareADraft_TestCase {
+
+	/**
+	 * Test that posts_results_intercept only processes supported post types
+	 */
+	public function test_posts_results_intercept_filters_by_post_type() {
+		// Create a draft post
+		$post_id = $this->create_draft( 'post' );
+		$post = get_post( $post_id );
+		$query = new WP_Query();
+
+		// Create a real share to get a valid key
+		$share = $this->create_share( $post_id );
+		$_GET['shareadraft'] = $share['key'];
+
+		// Should intercept supported post type
+		$result = $this->plugin->posts_results_intercept( array( $post ), $query );
+		$this->assertNotNull( $this->plugin->shared_post );
+
+		// Reset
+		$this->plugin->shared_post = null;
+
+		// Create an unsupported post type
+		$this->register_test_post_type( 'internal', array(
+			'public' => false,
+			'publicly_queryable' => false,
+		) );
+
+		$internal_post = $this->create_draft( 'internal' );
+		$internal_post_obj = get_post( $internal_post );
+
+		// Should NOT intercept unsupported post type
+		$result = $this->plugin->posts_results_intercept( array( $internal_post_obj ), $query );
+		$this->assertNull( $this->plugin->shared_post );
+	}
+
+	/**
+	 * Test that the_posts_intercept handles 'any' post_type query
+	 */
+	public function test_the_posts_intercept_allows_any_post_type() {
+		$post_id = $this->create_draft( 'post' );
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = 'any';
+
+		// Should inject post when post_type is 'any'
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( $post_id, $result[0]->ID );
+	}
+
+	/**
+	 * Test that the_posts_intercept allows injection when post_type is empty
+	 */
+	public function test_the_posts_intercept_allows_empty_post_type() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = '';
+
+		// Should inject post when post_type is empty
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( $post_id, $result[0]->ID );
+	}
+
+	/**
+	 * Test that the_posts_intercept blocks injection for FSE template queries
+	 */
+	public function test_the_posts_intercept_blocks_fse_template_injection() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = 'wp_template_part';
+
+		// Should NOT inject blog post into template query
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that the_posts_intercept blocks injection for wp_template queries
+	 */
+	public function test_the_posts_intercept_blocks_wp_template_injection() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = 'wp_template';
+
+		// Should NOT inject blog post into template query
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that the_posts_intercept allows injection for supported post types
+	 */
+	public function test_the_posts_intercept_allows_supported_post_types() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = 'post';
+
+		// Should inject when querying for 'post'
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( $post_id, $result[0]->ID );
+	}
+
+	/**
+	 * Test that the_posts_intercept handles array of post types
+	 */
+	public function test_the_posts_intercept_handles_post_type_array() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = array( 'post', 'page' );
+
+		// Should inject when 'post' is in the array
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( $post_id, $result[0]->ID );
+	}
+
+	/**
+	 * Test that the_posts_intercept blocks when array contains only unsupported types
+	 */
+	public function test_the_posts_intercept_blocks_unsupported_array() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = $post;
+
+		$query = new WP_Query();
+		$query->query_vars['post_type'] = array( 'wp_template', 'wp_template_part' );
+
+		// Should NOT inject when array contains only unsupported types
+		$result = $this->plugin->the_posts_intercept( array(), $query );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test that shared_post is reset when posts are returned
+	 */
+	public function test_the_posts_intercept_resets_shared_post() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'publish',
+			'post_type' => 'post',
+		) );
+
+		$post = get_post( $post_id );
+		$this->plugin->shared_post = get_post( $post_id );
+
+		$query = new WP_Query();
+
+		// When posts are returned, shared_post should be reset
+		$result = $this->plugin->the_posts_intercept( array( $post ), $query );
+		$this->assertNull( $this->plugin->shared_post );
+	}
+}

--- a/tests/test-share-validation.php
+++ b/tests/test-share-validation.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for share creation validation
+ */
+
+class Test_ShareADraft_Validation extends ShareADraft_TestCase {
+
+	/**
+	 * Test that sharing a post draft succeeds
+	 */
+	public function test_can_share_post_draft() {
+		$post_id = $this->create_draft( 'post' );
+		$share = $this->create_share( $post_id );
+
+		$this->assertNotNull( $share );
+		$this->assertEquals( $post_id, $share['id'] );
+	}
+
+	/**
+	 * Test that sharing a page draft succeeds
+	 */
+	public function test_can_share_page_draft() {
+		$page_id = $this->create_draft( 'page' );
+		$share = $this->create_share( $page_id );
+
+		$this->assertNotNull( $share );
+		$this->assertEquals( $page_id, $share['id'] );
+	}
+
+	/**
+	 * Test that sharing an unsupported post type fails
+	 */
+	public function test_cannot_share_unsupported_post_type() {
+		// Register a non-publicly-queryable type
+		$this->register_test_post_type( 'internal', array(
+			'public' => false,
+			'publicly_queryable' => false,
+		) );
+
+		$post_id = $this->create_draft( 'internal' );
+		$share = $this->create_share( $post_id );
+
+		// Should return null (failed to create share)
+		$this->assertNull( $share );
+	}
+
+	/**
+	 * Test that sharing a published post fails
+	 */
+	public function test_cannot_share_published_post() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'publish',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$result = $this->plugin->process_new_share( array(
+			'post_id' => $post_id,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'published', $result );
+
+		$shares = $this->plugin->get_shared();
+		$this->assertEmpty( $shares );
+	}
+
+	/**
+	 * Test that sharing a non-existent post fails
+	 */
+	public function test_cannot_share_nonexistent_post() {
+		$result = $this->plugin->process_new_share( array(
+			'post_id' => 999999,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'no such post', $result );
+	}
+
+	/**
+	 * Test that user cannot share post they cannot edit
+	 */
+	public function test_cannot_share_post_without_permission() {
+		// Create a post by another user
+		$other_user = $this->factory->user->create( array( 'role' => 'author' ) );
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $other_user,
+		) );
+
+		// Switch to a subscriber who can't edit others' posts
+		$subscriber = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
+
+		$result = $this->plugin->process_new_share( array(
+			'post_id' => $post_id,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'not allowed', $result );
+	}
+
+	/**
+	 * Test that sharing custom publicly queryable post type succeeds
+	 */
+	public function test_can_share_custom_publicly_queryable_type() {
+		$this->register_test_post_type( 'event', array(
+			'public' => true,
+			'publicly_queryable' => true,
+		) );
+
+		$post_id = $this->create_draft( 'event' );
+		$share = $this->create_share( $post_id );
+
+		$this->assertNotNull( $share );
+		$this->assertEquals( $post_id, $share['id'] );
+	}
+}

--- a/tests/test-url-generation.php
+++ b/tests/test-url-generation.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Tests for URL generation for different post types
+ */
+
+class Test_ShareADraft_URLGeneration extends ShareADraft_TestCase {
+
+	/**
+	 * Helper to create a share and extract the generated URL from output
+	 */
+	private function get_share_url_from_output( $post_id ) {
+		// Create a share
+		$this->plugin->process_new_share( array(
+			'post_id' => $post_id,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		// Capture output
+		ob_start();
+		$this->plugin->output_existing_menu_sub_admin_page();
+		$output = ob_get_clean();
+
+		// Extract URL from output
+		preg_match( '/href="([^"]*shareadraft=[^"]*)"/i', $output, $matches );
+		return isset( $matches[1] ) ? html_entity_decode( $matches[1] ) : '';
+	}
+
+	/**
+	 * Test that post URLs use ?p= parameter
+	 */
+	public function test_post_url_uses_p_parameter() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'post_title' => 'Test Post',
+			'author' => $this->user_id,
+		) );
+
+		$url = $this->get_share_url_from_output( $post_id );
+
+		$this->assertStringContainsString( '?p=' . $post_id, $url );
+		$this->assertStringContainsString( '&shareadraft=', $url );
+		$this->assertStringNotContainsString( 'page_id=', $url );
+		$this->assertStringNotContainsString( 'post_type=', $url );
+	}
+
+	/**
+	 * Test that page URLs use ?page_id= parameter
+	 */
+	public function test_page_url_uses_page_id_parameter() {
+		$page_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'page',
+			'post_title' => 'Test Page',
+			'author' => $this->user_id,
+		) );
+
+		$url = $this->get_share_url_from_output( $page_id );
+
+		$this->assertStringContainsString( '?page_id=' . $page_id, $url );
+		$this->assertStringContainsString( '&shareadraft=', $url );
+		$this->assertStringNotContainsString( '?p=', $url );
+	}
+
+	/**
+	 * Test that custom post type URLs include post_type parameter
+	 */
+	public function test_custom_post_type_url_includes_post_type() {
+		$this->register_test_post_type( 'event', array(
+			'public' => true,
+			'publicly_queryable' => true,
+		) );
+
+		$event_id = $this->create_draft( 'event', array( 'post_title' => 'Test Event' ) );
+		$url = $this->get_share_url_from_output( $event_id );
+
+		$this->assertStringContainsString( '?post_type=event', $url );
+		$this->assertStringContainsString( '&p=' . $event_id, $url );
+		$this->assertStringContainsString( '&shareadraft=', $url );
+	}
+
+	/**
+	 * Test that all share URLs include the shareadraft key
+	 */
+	public function test_all_urls_include_shareadraft_key() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$url = $this->get_share_url_from_output( $post_id );
+
+		$this->assertStringContainsString( 'shareadraft=', $url );
+
+		// Verify the key format (should start with 'baba')
+		preg_match( '/shareadraft=([^&"]+)/', $url, $matches );
+		$this->assertNotEmpty( $matches[1] );
+		$this->assertStringStartsWith( 'baba', $matches[1] );
+	}
+
+	/**
+	 * Test that URL generation handles multiple post types correctly
+	 */
+	public function test_multiple_post_types_generate_correct_urls() {
+		// Create multiple post types
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'post_title' => 'Test Post',
+			'author' => $this->user_id,
+		) );
+
+		$page_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'page',
+			'post_title' => 'Test Page',
+			'author' => $this->user_id,
+		) );
+
+		register_post_type( 'portfolio', array(
+			'public' => true,
+			'publicly_queryable' => true,
+		) );
+
+		$portfolio_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'portfolio',
+			'post_title' => 'Test Portfolio',
+			'author' => $this->user_id,
+		) );
+
+		// Share all three
+		$this->plugin->process_new_share( array(
+			'post_id' => $post_id,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		$this->plugin->process_new_share( array(
+			'post_id' => $page_id,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		$this->plugin->process_new_share( array(
+			'post_id' => $portfolio_id,
+			'expires' => 2,
+			'measure' => 'w',
+		) );
+
+		// Capture output
+		ob_start();
+		$this->plugin->output_existing_menu_sub_admin_page();
+		$output = ob_get_clean();
+
+		// Verify all three have correct URL patterns
+		$this->assertStringContainsString( '?p=' . $post_id . '&amp;shareadraft=', $output );
+		$this->assertStringContainsString( '?page_id=' . $page_id . '&amp;shareadraft=', $output );
+		$this->assertStringContainsString( '?post_type=portfolio&amp;p=' . $portfolio_id . '&amp;shareadraft=', $output );
+
+		unregister_post_type( 'portfolio' );
+	}
+
+	/**
+	 * Test that base URL is correctly included
+	 */
+	public function test_urls_include_site_base_url() {
+		$post_id = $this->factory->post->create( array(
+			'post_status' => 'draft',
+			'post_type' => 'post',
+			'author' => $this->user_id,
+		) );
+
+		$url = $this->get_share_url_from_output( $post_id );
+		$site_url = get_bloginfo( 'url' );
+
+		$this->assertStringStartsWith( $site_url, $url );
+	}
+}


### PR DESCRIPTION
* We chose publicly queryable as the criteria closest to the intended use case.
* The posts from all supported post types are listed together in the dropdown.
* For now we don't indicate the post type in the list but may later.
* The URL now includes the correct post type.
* We also only inject the shared post in queries for the supported post types, this fixes FSE issues, see #6.
* Adds tests for most of the functionality, because this is a bigger change and we didn't have any :)
